### PR TITLE
Add fake ofFloatColor support

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -14,6 +14,7 @@ void ofApp::setup(){
     gui.add(floatParam.set("float parameter", 1.111, 0.0, 10.0));
     gui.add(strParam.set("some text", "bla"));
     gui.add(clrParam.set("Color", ofColor::azure));
+    gui.add(clrParamF.set("Color Float", ofFloatColor::red));
 
 
     //----------------------------------------
@@ -60,6 +61,7 @@ void ofApp::setup(){
     group.add(dblParam);
     group.add(floatParam);
     group.add(clrParam);
+    group.add(clrParamF);
 
     // expose whole group via rabbit
     rabbit.expose(group);

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -40,6 +40,7 @@ public:
     ofParameter<bool> boolParam;
     ofParameter<std::string> strParam;
     ofParameter<ofColor> clrParam;
+    ofParameter<ofFloatColor> clrParamF;
 
     ofxRabbitControlServer rabbit;
     websocketServerTransporter transporter;

--- a/src/ofxRabbitControl.h
+++ b/src/ofxRabbitControl.h
@@ -56,6 +56,7 @@ public:
     rcp::Float64ParameterPtr expose(ofParameter<double> & param, const rcp::GroupParameterPtr& rabbitgroup = rcp::GroupParameterPtr());
     rcp::StringParameterPtr expose(ofParameter<std::string> & param, const rcp::GroupParameterPtr& rabbitgroup = rcp::GroupParameterPtr());
     rcp::RGBAParameterPtr expose(ofParameter<ofColor> & param, const rcp::GroupParameterPtr& rabbitgroup = rcp::GroupParameterPtr());
+    rcp::RGBAParameterPtr expose(ofParameter<ofFloatColor> & param, const rcp::GroupParameterPtr& rabbitgroup = rcp::GroupParameterPtr());
 
     void remove(ofParameter<bool> & param);
     void remove(ofParameter<char> & param);
@@ -64,7 +65,8 @@ public:
     void remove(ofParameter<double> & param);
     void remove(ofParameter<std::string> & param);
     void remove(ofParameter<ofColor> & param);
-
+    void remove(ofParameter<ofFloatColor> & param);
+    
     void paramBoolChanged(bool & value);
     void paramInt8Changed(char & value);
     void paramInt32Changed(int & value);
@@ -72,7 +74,8 @@ public:
     void paramDoubleChanged(double & value);
     void paramStringChanged(std::string & value);
     void paramColorChanged(ofColor & value);
-
+    void paramFloatColorChanged(ofFloatColor & value);
+    
 private:
     int16_t findParam(void* paramAdr);
 


### PR DESCRIPTION
Regarding this issue https://github.com/rabbitControl/ofxRabbitControl/issues/2

I found we need detailed care of rcp lib itself as rcp::Color only supports 8bit colour.
So I decided to make a quick and fake version of ofFloatColor support, just converting ofFLoatColor to ofColor.

Please notice that 
- ofFloatColor has 4 channels of 32bit float numbers
- ofColor has 4 channels of 8bit char numbers
By converting ofFloatColor to ofColor, we lose precision.
So we need "real" ofFloatColor support later.